### PR TITLE
MRG: downgrade to v0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "sourmash_plugin_pangenomics"
 description = "sourmash plugin to do pangenomics."
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.3"
+version = "0.2"
 authors = [
   {name = "Colton Baumler", email = "ccbaumler@ucdavis.edu"},
   {name = "Titus Brown", email = "titus@idyll.org"},


### PR DESCRIPTION
I goofed and thought last release was v0.2, so bumped version to 0.3 - but I was wrong! We still need a v0.2 release.