### PR TITLE
MRG: fix some code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "sourmash_plugin_pangenomics"
 description = "sourmash plugin to do pangenomics."
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.2.1"
+version = "0.2.2"
 authors = [
   {name = "Colton Baumler", email = "ccbaumler@ucdavis.edu"},
   {name = "Titus Brown", email = "titus@idyll.org"},

--- a/src/sourmash_plugin_pangenomics.py
+++ b/src/sourmash_plugin_pangenomics.py
@@ -145,7 +145,7 @@ class Command_RankTable(CommandLinePlugin):
         p.add_argument(
             "-o",
             "--output-hash-classification",
-            required=False,
+            required=True,
             help="CSV file containing classification of each hash",
         )
         sourmash_utils.add_standard_minhash_args(p)
@@ -447,7 +447,7 @@ def db_process(
 
         for n, ss in enumerate(db.signatures()):
             if n % 10 == 0:
-                print(f"...Processing {n} of {len(mf)}", end="\r", flush=True)
+                print(f"...Processing {n} of {len(db)}", end="\r", flush=True)
 
                 name = ss.name
 
@@ -455,7 +455,7 @@ def db_process(
                 hashes = mh.hashes
                 ss_dict[name] = hashes
 
-            print(f"...Processed {n} of {len(mf)} \n")
+            print(f"...Processed {n+1} of {len(db)} \n")
 
     return ss_dict
 


### PR DESCRIPTION
broke some stuff in #15, oops.

This also bumps the version to 0.2.2 and changes `pangenome_ranktable` to require an output filename.