### PR TITLE
[MRG] Fix ranktable issue of hash abund counting

### DIFF
--- a/src/sourmash_plugin_pangenomics.py
+++ b/src/sourmash_plugin_pangenomics.py
@@ -64,6 +64,7 @@ class Command_CreateDB(CommandLinePlugin):
         super().__init__(subparser)
         p = subparser
 
+        p.add_argument("--empty")
         p.add_argument(
             "-t",
             "--taxonomy-file",
@@ -255,11 +256,11 @@ def pangenome_createdb_main(args):
 
             # Accumulate the count within lineage names if `--abund` in cli
             if args.abund:
-                c = Counter(ss.minhash.hashes)
+                c = set(ss.minhash.hashes)
                 if lineage_name in counts:
                     counts[lineage_name].update(c)
                 else:
-                    counts[lineage_name] = c
+                    counts[lineage_name] = Counter(c)
 
             # track merged sketches
             mh = revtax_d.get(lineage_name)

--- a/src/sourmash_plugin_pangenomics.py
+++ b/src/sourmash_plugin_pangenomics.py
@@ -64,7 +64,6 @@ class Command_CreateDB(CommandLinePlugin):
         super().__init__(subparser)
         p = subparser
 
-        p.add_argument("--empty")
         p.add_argument(
             "-t",
             "--taxonomy-file",

--- a/src/sourmash_plugin_pangenomics.py
+++ b/src/sourmash_plugin_pangenomics.py
@@ -255,11 +255,14 @@ def pangenome_createdb_main(args):
 
             # Accumulate the count within lineage names if `--abund` in cli
             if args.abund:
-                c = set(ss.minhash.hashes)
+                # explicitly discard abundances when counting an individual
+                # sketch by using `set` to force this to an iteratable
+                # rather than a mapping
+                c = Counter(set(ss.minhash.hashes))
                 if lineage_name in counts:
                     counts[lineage_name].update(c)
                 else:
-                    counts[lineage_name] = Counter(c)
+                    counts[lineage_name] = c
 
             # track merged sketches
             mh = revtax_d.get(lineage_name)


### PR DESCRIPTION
fixes #28 

I use the Counter only once the hashes are converted to a set. I think the abundance from the original database was being summed instead of the presence of the hash. Converting to a set separates the hashes from this abundance and returns more expected results:

Here we can see that I should expect 225 genomes for the species `Ralstonia_solanacearum`:

```
$ awk -F',' '{print $1}' ralstonia_solanacearum.species.csv | sort | uniq -c
      1 s__Ralstonia insidiosa
    139 s__Ralstonia nicotianae
      3 s__Ralstonia pseudosolanacearum
    225 s__Ralstonia solanacearum
     13 s__Ralstonia syzygii
```

Now the ranktable reflects this expected maximum:
```
hashval,freq,abund,max_abund
114148039631883,1.0,225,225
168403348314061,1.0,225,225
540207057884172,1.0,225,225
732563087889815,1.0,225,225
863785382968438,1.0,225,225
994847855991356,1.0,225,225
1256505096875354,1.0,225,225
1281108779577038,1.0,225,225
1293913287130232,1.0,225,225
1437724181133342,1.0,225,225
```

http://farm.cse.ucdavis.edu/~baumlerc/ralstonia_solanacearum.species.fixabund.png

As compared to the original where Counter was used immediately:

http://farm.cse.ucdavis.edu/~baumlerc/gtdb-rs226-k31.species.GCF_036628375_s__Ralstonia_solanacearum.png