### PR TITLE
fix empty lineage bug found with script test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "sourmash_plugin_pangenomics"
 description = "sourmash plugin to do pangenomics."
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.4.0"
+version = "0.4.1"
 authors = [
   {name = "Colton Baumler", email = "ccbaumler@ucdavis.edu"},
   {name = "Titus Brown", email = "titus@idyll.org"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "sourmash_plugin_pangenomics"
 description = "sourmash plugin to do pangenomics."
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.4.1"
+version = "0.4.2"
 authors = [
   {name = "Colton Baumler", email = "ccbaumler@ucdavis.edu"},
   {name = "Titus Brown", email = "titus@idyll.org"},

--- a/src/sourmash_plugin_pangenomics.py
+++ b/src/sourmash_plugin_pangenomics.py
@@ -96,8 +96,11 @@ class Command_CreateDB(CommandLinePlugin):
         p.add_argument(
             "-a",
             "--abund",
-            action="store_true",
-            help="Enable abundance tracking of hashes across rank selection. I.e. Bastardize the abundance metric to count frequency across genomes instead of abundance of kmer across genomes.",
+            default='genome',
+            const='genome',
+            nargs='?',
+            choices=['kmer','genome'],
+            help="Enable abundance tracking of hashes across rank selection or the standard kmer abundance accumulation across genomes. I.e. Bastardize the abundance metric to count frequency across genomes instead of abundance of kmer across genomes.",
         )
         sourmash_utils.add_standard_minhash_args(p)
 
@@ -276,11 +279,17 @@ def pangenome_createdb_main(args):
                 revtax_d[lineage_name] += ss.minhash
 
             if do_abund:
-                counts[lineage_name].update(set(ss.minhash.hashes))
+                if do_abund == 'genome':
+                    counts[lineage_name].update(set(ss.minhash.hashes))
+                elif do_abund == 'kmer':
+                    counts[lineage_name].update(ss.minhash.hashes)
+                else:
+                    print('"-a" or "--abund" requires either "kmer" or "genome". Defaulting to "genome".')
+                    sys.exit(1)
 
-                top_hash, top_count = counts[lineage_name].most_common(1)[0]
-                print("Most Abundant Hash:", top_hash)
-                print("Highest Count:", top_count)
+                #top_hash, top_count = counts[lineage_name].most_common(1)[0]
+                #print("Most Abundant Hash:", top_hash)
+                #print("Highest Count:", top_count)
 
             if do_csv:
                 hash_count = len(revtax_d[lineage_name].hashes)

--- a/src/sourmash_plugin_pangenomics.py
+++ b/src/sourmash_plugin_pangenomics.py
@@ -265,7 +265,10 @@ def pangenome_createdb_main(args):
             lineage_pair = lineage_tup.lineage_at_rank(target_rank)
             lineage_name = lineage_pair[-1].name
 
-            ident_d[lineage_name] = ident
+            if lineage_name not in ident_d:
+                ident_d[lineage_name] = ident
+            else:
+                ident_d[lineage_name] = min(ident_d[lineage_name], ident)
 
             if lineage_name not in revtax_d:
                 revtax_d[lineage_name] = ss.minhash.to_mutable()

--- a/src/sourmash_plugin_pangenomics.py
+++ b/src/sourmash_plugin_pangenomics.py
@@ -53,6 +53,12 @@ NAMES = {
 # CLI plugins - supports 'sourmash scripts <commands>'
 #
 
+class CustomRankLineageInfo(tax_utils.RankLineageInfo):
+    def lineage_at_rank(self, rank):
+        "Return tuple of LineagePairs at specified rank, including empty ranks."
+        self.check_rank_availability(rank)
+        rank_idx = self.rank_index(rank)
+        return self.lineage[: rank_idx + 1]
 
 class Command_CreateDB(CommandLinePlugin):
     command = "pangenome_createdb"  # 'scripts <command>'
@@ -221,7 +227,9 @@ def pangenome_createdb_main(args):
     select_mh = sourmash_utils.create_minhash_from_args(args)
     print(f"Selecting sketches: {select_mh}")
 
-    for filename in args.sketches:
+    missing_idents = set()
+
+    for filename in sorted(args.sketches):
         print(f"Loading sketches from file {filename}")
         db = sourmash_utils.load_index_and_select(filename, select_mh)
 
@@ -237,21 +245,23 @@ def pangenome_createdb_main(args):
 
             if lineage_tup is None:
                 if "." in ident:
-                    lineage_tup = taxdb.get(ident.split(".")[0])
+                    a_ident = ident.split(".")[0]
+                    lineage_tup = taxdb.get(a_ident)
+                    if lineage_tup is not None:
+                        ident = a_ident
                 else:
                     for i in range(1, 10):
-                        lineage_tup = taxdb.get(f"{ident}.{i}")
+                        b_ident = f"{ident}.{i}"
+                        lineage_tup = taxdb.get(b_ident)
                         if lineage_tup is not None:
+                            ident = b_ident
                             break
 
             if lineage_tup is None:
-                print(f"Cannot find ident '{ident}' in the provided taxonomy file.")
-                print(f"The three closest matches to '{ident}' are:")
-                for k in get_close_matches(ident, taxdb.keys(), n=3):
-                    print(f"* '{k}'")
-                sys.exit(-1)
+                missing_idents.add(ident)
+                continue
 
-            lineage_tup = tax_utils.RankLineageInfo(lineage=lineage_tup)
+            lineage_tup = CustomRankLineageInfo(lineage=lineage_tup)
             lineage_pair = lineage_tup.lineage_at_rank(target_rank)
             lineage_name = lineage_pair[-1].name
 
@@ -265,22 +275,39 @@ def pangenome_createdb_main(args):
             if do_abund:
                 counts[lineage_name].update(set(ss.minhash.hashes))
 
+                top_hash, top_count = counts[lineage_name].most_common(1)[0]
+                print("Most Abundant Hash:", top_hash)
+                print("Highest Count:", top_count)
+
             if do_csv:
                 hash_count = len(revtax_d[lineage_name].hashes)
                 chunk.append({
                     "lineage": lineage_name,
-                    "sig_name": name,
+                    "sig_name": sig_name, 
                     "hash_count": hash_count,
                     "genome_count": n,
                 })
 
-                # Write chunk if it reaches capacity
                 if len(chunk) >= 1000:
                     write_chunk(chunk, csv_file)
                     chunk = []
 
     if do_csv and chunk:
         write_chunk(chunk, csv_file)
+
+    if missing_idents:
+        print(f"\nProcessing {len(missing_idents)} unique missing lineages...")
+        taxdb_keys = list(taxdb.keys())  # Convert once for speed
+
+        with open("failed_to_find_lineage.txt", "w") as f:
+            for missing_id in missing_idents:
+                print(f"Cannot find ident '{missing_id}' in the provided taxonomy file.", file=f)
+                print(f"The three closest matches to '{missing_id}' are:", file=f)
+
+                # Expensive fuzzy matching only runs ONCE per missing unique ID
+                for k in get_close_matches(missing_id, taxdb_keys, n=3):
+                    print(f"* '{k}'", file=f)
+                print("", file=f)
 
     print(f"Writing output sketches to '{args.output}'")
     with sourmash_args.SaveSignaturesToLocation(args.output) as save_sigs:

--- a/test_workflow/Snakefile
+++ b/test_workflow/Snakefile
@@ -21,10 +21,22 @@ rule merge_agatha:
         db="gtdb-rs214-agatha-k21.zip",
         tax="gtdb-rs214-agatha.lineages.csv.gz",
     output:
-        pangenome_sig="test_output/agatha-merged.sig.zip",
+        pangenome_sig="test_output/agatha-merged-genome-abund.sig.zip",
     shell: """
         sourmash scripts pangenome_createdb {input.db} -t {input.tax} \
             -o {output} --abund -k 21 --dna --scaled=1000
+	    #no rank defaults to species
+    """
+ 
+rule merge_agatha_no_abund:
+    input:
+        db="gtdb-rs214-agatha-k21.zip",
+        tax="gtdb-rs214-agatha.lineages.csv.gz",
+    output:
+        pangenome_sig="test_output/agatha-merged-no-abund.sig.zip",
+    shell: """
+        sourmash scripts pangenome_createdb {input.db} -t {input.tax} \
+            -o {output} -k 21 --dna --scaled=1000
 	    #no rank defaults to species
     """
         

--- a/test_workflow/Snakefile
+++ b/test_workflow/Snakefile
@@ -59,7 +59,7 @@ rule build_classify_hashes:
         csv="test_output/agathobacter_faecis.csv",
     params:
         ksize=21,
-        name="GCF_020557615 s__Agathobacter faecis",
+        name="GCF_020557615.1 s__Agathobacter faecis",
     shell: """
         sourmash scripts pangenome_ranktable {input.pangenome_sig} \
 	     --taxonomy-file {input.tax} --rank species \

--- a/test_workflow/Snakefile
+++ b/test_workflow/Snakefile
@@ -1,6 +1,7 @@
 rule all:
     input:
-        "test_output/agatha-merged.sig.zip",
+        "test_output/agatha-merged-genome-abund.sig.zip",
+        "test_output/agatha-merged-no-abund.sig.zip",
         "test_output/agatha-merged-2.sig.zip",
         "test_output/agathobacter_faecis.csv",
         "test_output/agathobacter_faecis_hashes.txt",
@@ -52,7 +53,7 @@ rule merge_agatha_2:
 
 rule build_classify_hashes:
     input:
-        pangenome_sig="test_output/agatha-merged.sig.zip",
+        pangenome_sig="test_output/agatha-merged-genome-abund.sig.zip",
         tax="gtdb-rs214-agatha.lineages.csv.gz",
     output:
         csv="test_output/agathobacter_faecis.csv",

--- a/test_workflow/Snakefile
+++ b/test_workflow/Snakefile
@@ -59,7 +59,7 @@ rule build_classify_hashes:
         csv="test_output/agathobacter_faecis.csv",
     params:
         ksize=21,
-        name="GCF_020557615.1 s__Agathobacter faecis",
+        name="GCA_000433615.1 s__Agathobacter faecis",
     shell: """
         sourmash scripts pangenome_ranktable {input.pangenome_sig} \
 	     --taxonomy-file {input.tax} --rank species \

--- a/tests/create_sample_sig.py
+++ b/tests/create_sample_sig.py
@@ -1,0 +1,120 @@
+#! /usr/bin/env python
+
+import json
+import csv
+import gzip
+import hashlib
+import os
+
+outdir = "sample-genomes"
+sigdir = os.path.join(outdir, "signatures")
+os.makedirs(sigdir, exist_ok=True)
+
+hashes = [100,200,300,400,500,600,700,800,900,1000]
+
+manifest_rows = []
+lineage_rows = []
+
+for genome in range(1, 11):
+
+    ident = f"GCA_{genome}.1"
+    name = f"Genome {genome}"
+    filename = f"sample-{genome}.sig.gz"
+    internal_location = f"signatures/{filename}"
+    sig_path = os.path.join(sigdir, filename)
+
+    abundances = [(i + 1) * genome for i in range(10)]
+
+    sig = [{
+        "class": "sourmash_signature",
+        "email": "",
+        "hash_function": "0.murmur64",
+        "filename": sig_path,
+        "name": ident + " " + name,
+        "license": "CC0",
+        "signatures": [{
+            "num": 0,
+            "ksize": 31,
+            "seed": 42,
+            "max_hash": 18446744073709552,
+            "mins": hashes,
+            "md5sum": hashlib.md5(
+                "".join(map(str, hashes)).encode()
+            ).hexdigest(),
+            "abundances": abundances,
+            "molecule": "DNA"
+        }],
+        "version": 0.4
+    }]
+
+    with gzip.open(sig_path, "wt") as fp:
+        json.dump(sig, fp)
+
+    md5 = hashlib.md5(
+        "".join(map(str, hashes)).encode()
+    ).hexdigest()
+
+    manifest_rows.append([
+        internal_location,
+        md5,
+        md5[:8],
+        31,
+        "DNA",
+        0,
+        1000,
+        len(hashes),
+        True,
+        name,
+        sig_path
+    ])
+
+    lineage_rows.append([
+        ident,
+        "t",
+        "d__Test",
+        "p__Test",
+        "c__Test",
+        "o__Test",
+        "f__Test",
+        "g__Test",
+        "s__Test"
+    ])
+
+manifest = os.path.join(outdir, "SOURMASH-MANIFEST.csv")
+
+with open(manifest, "w", newline="") as fp:
+    fp.write("# SOURMASH-MANIFEST-VERSION: 1.0\n")
+
+    writer = csv.writer(fp)
+    writer.writerow([
+        "internal_location",
+        "md5",
+        "md5short",
+        "ksize",
+        "moltype",
+        "num",
+        "scaled",
+        "n_hashes",
+        "with_abundance",
+        "name",
+        "filename"
+    ])
+
+    writer.writerows(manifest_rows)
+
+with open("lineages.sample-genomes.csv", "w") as fp:
+    writer = csv.writer(fp)
+
+    writer.writerow([
+        "ident",
+        "gtdb_representative",
+        "superkingdom",
+        "phylum",
+        "class",
+        "order",
+        "family",
+        "genus",
+        "species"
+    ])
+
+    writer.writerows(lineage_rows)


### PR DESCRIPTION
missing lineages in viral lineage taxonomy files were breaking the workflow as GenBank does not always completely fill out lineage even with updates. 

Added a class mimicing the tax_utils class of similar name but to allow for none types to be used for the lineage rank we seek instead of the closest with non-None value.

Also started to add tests with a simple script to build a standard set of example sketches with lineage and manifest files to mimic the entire database. Used to identify some of these bugs.